### PR TITLE
Added support for the "information and survey" tab and date refactoring

### DIFF
--- a/pronotepy/clients.py
+++ b/pronotepy/clients.py
@@ -164,7 +164,6 @@ class _ClientBase:
         json = self.func_options['donneesSec']['donnees']['General']['ListePeriodes']
         return [dataClasses.Period(self, j) for j in json]
 
-
     def keep_alive(self):
         """
         Returns a context manager to keep the connection alive. When inside the context manager,
@@ -344,6 +343,23 @@ class Client(_ClientBase):
         messages = self.post('ListeMessagerie', 131, {'avecMessage': True, 'avecLu': True})
         return [dataClasses.Message(self, m) for m in messages['donneesSec']['donnees']['listeMessagerie']['V']
                 if not m.get('estUneDiscussion')]
+
+    def information_and_surveys(self, only_unread: bool = False) -> List[dataClasses.Information]:
+        """
+        Gets all the information and surveys in the information and surveys tab
+
+        Returns
+        -------
+        List[Information]
+            Information
+        """
+        response = self.post('PageActualites', 8, {'estAuteur': False})
+        info = [dataClasses.Information(self, info) for info in
+                response['donneesSec']['donnees']['listeActualites']['V']]
+
+        if only_unread:
+            return [i for i in info if not i.read]
+        return info
 
     @property
     def current_period(self) -> dataClasses.Period:

--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -73,8 +73,8 @@ class Util:
             return string
 
     @staticmethod
-    def date_parse(formatted_date: str) -> datetime.datetime:
-        """convert date to a datetime.datetime object"""
+    def date_parse(formatted_date: str) -> datetime.date:
+        """convert date to a datetime.date object"""
         if re.match(r"\d{2}/\d{2}/\d{4}$", formatted_date):
             return datetime.datetime.strptime(formatted_date, '%d/%m/%Y').date()
         elif re.match(r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}$", formatted_date):

--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -97,7 +97,7 @@ class Util:
             log.warning("date parsing not possible for value '" + formatted_date + "' set to None")
 
     @staticmethod
-    def htlm_parse(html_text: str) -> str:
+    def html_parse(html_text: str) -> str:
         """remove tags from html text"""
         return unescape(re.sub(re.compile('<.*?>'), '', html_text))
 
@@ -494,7 +494,7 @@ class LessonContent:
 
     attribute_guide = {
         'L': ('title', str),
-        'descriptif,V': ('description', Util.htlm_parse),
+        'descriptif,V': ('description', Util.html_parse),
         'ListePieceJointe,V': ('_files', tuple)
     }
 
@@ -608,7 +608,7 @@ class Homework:
     __slots__ = ['id', 'subject', 'description', 'done', 'background_color', '_client', 'date', '_files']
     attribute_guide = {
         'N': ('id', str),
-        'descriptif,V': ('description', Util.htlm_parse),
+        'descriptif,V': ('description', Util.html_parse),
         'TAFFait': ('done', bool),
         'Matiere,V': ('subject', Subject),
         'CouleurFond': ('background_color', str),
@@ -711,7 +711,7 @@ class Information:
 
     @property
     def content(self):
-        return Util.htlm_parse(self._raw_content[0]['texte']['V'])
+        return Util.html_parse(self._raw_content[0]['texte']['V'])
 
     def mark_as_read(self, status: bool):
         data = {
@@ -784,7 +784,7 @@ class Message:
         for m in resp['donneesSec']['donnees']['listeMessages']['V']:
             if m['N'] == self.id:
                 if type(m['contenu']) == dict:
-                    return Util.htlm_parse(m['contenu']['V'])
+                    return Util.html_parse(m['contenu']['V'])
                 else:
                     return m['contenu']
         return None

--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -146,8 +146,8 @@ class Period:
         self._client = client
         self.id = parsed_json['N']
         self.name = parsed_json['L']
-        self.start = Util.date_parse(parsed_json['dateDebut']['V'], '%d/%m/%Y')
-        self.end = Util.date_parse(parsed_json['dateFin']['V'], '%d/%m/%Y')
+        self.start = Util.date_parse(parsed_json['dateDebut']['V'])
+        self.end = Util.date_parse(parsed_json['dateFin']['V'])
 
     @property
     def grades(self):

--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -729,8 +729,7 @@ class Information:
             ],
             "saisieActualite": False
         }
-        if self._client.post("SaisieActualites", 8, data):
-            self.read = status
+        self.read = status
 
 
 class Message:

--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -76,6 +76,18 @@ class Util:
     def date_parse(formatted_date: str) -> datetime.datetime:
         """convert date to a datetime.datetime object"""
         if re.match(r"\d{2}/\d{2}/\d{4}$", formatted_date):
+            return datetime.datetime.strptime(formatted_date, '%d/%m/%Y').date()
+        elif re.match(r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}$", formatted_date):
+            return datetime.datetime.strptime(formatted_date, '%d/%m/%Y %H:%M:%S').date()
+        elif re.match(r"\d{2}/\d{2}/\d{2} \d{2}h\d{2}$", formatted_date):
+            return datetime.datetime.strptime(formatted_date, '%d/%m/%y %Hh%M').date()
+        else:
+            log.warning("date parsing not possible for value '" + formatted_date + "' set to None")
+
+    @staticmethod
+    def datetime_parse(formatted_date: str) -> datetime.datetime:
+        """convert date to a datetime.datetime object"""
+        if re.match(r"\d{2}/\d{2}/\d{4}$", formatted_date):
             return datetime.datetime.strptime(formatted_date, '%d/%m/%Y')
         elif re.match(r"\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}$", formatted_date):
             return datetime.datetime.strptime(formatted_date, '%d/%m/%Y %H:%M:%S')
@@ -146,8 +158,8 @@ class Period:
         self._client = client
         self.id = parsed_json['N']
         self.name = parsed_json['L']
-        self.start = Util.date_parse(parsed_json['dateDebut']['V'])
-        self.end = Util.date_parse(parsed_json['dateFin']['V'])
+        self.start = Util.datetime_parse(parsed_json['dateDebut']['V'])
+        self.end = Util.datetime_parse(parsed_json['dateFin']['V'])
 
     @property
     def grades(self):
@@ -384,7 +396,7 @@ class Lesson:
                  'end', 'outing', 'group_name', 'student_class', 'exempted',
                  '_client', '_content', 'virtual_classrooms', 'num']
     attribute_guide = {
-        'DateDuCours,V': ('start', Util.date_parse),
+        'DateDuCours,V': ('start', Util.datetime_parse),
         'N': ('id', str),
         'estAnnule': ('canceled', bool),
         'Statut': ('status', str),
@@ -751,7 +763,7 @@ class Message:
         'public_gauche': ('author', str),
         'listePublic': ('recipients', list),
         'lu': ('seen', bool),
-        'libelleDate': ('date', lambda d: Util.date_parse(' '.join(d.split()[1:])))
+        'libelleDate': ('date', lambda d: Util.datetime_parse(' '.join(d.split()[1:])))
     }
 
     def __init__(self, client, json_):

--- a/pronotepy/test_pronotepy.py
+++ b/pronotepy/test_pronotepy.py
@@ -39,6 +39,14 @@ class TestClient(unittest.TestCase):
             self.assertLessEqual(start, hw.date)
             self.assertLessEqual(hw.date, end)
 
+    def test_information(self):
+        information = client.information_and_surveys()
+        self.assertGreater(len(information), 0)
+        for i in information:
+            self.assertIsNotNone(i.author)
+            self.assertIsNotNone(i.creation_date)
+            self.assertIsInstance(i.survey, bool)
+
     def test_refresh(self):
         client.refresh()
         self.assertEqual(client.session_check(), True)


### PR DESCRIPTION
- Added support for the "information and survey" tab in dataClass.Information objects
- modification of the date system because the dates returned by the API can be in different formats for a same call

tell me if anything seems wrong or you think of a better way