### PR TITLE
logging fix

### DIFF
--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -11,7 +11,6 @@ from Crypto.Util import Padding
 from .exceptions import ParsingError
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
 
 
 def _get_l(d): return d['L']


### PR DESCRIPTION
leave the default logging level to WARN to avoid overloading the logs