### PR TITLE
add Client.export_ical method

### DIFF
--- a/pronotepy/exceptions.py
+++ b/pronotepy/exceptions.py
@@ -24,6 +24,7 @@ class ExpiredObject(PronoteAPIError):
 
 class ChildNotFound(PronoteAPIError):
     """Child with this name was not found."""
+    pass
 
 
 class DataError(Exception):
@@ -39,3 +40,8 @@ class ParsingError(DataError):
         super().__init__(message)
         self.json_dict = json_dict
         self.path = path
+
+
+class ICalExportError(PronoteAPIError):
+    """Error while exporting ICal. Pronote did not return token"""
+    pass

--- a/pronotepy/test_pronotepy.py
+++ b/pronotepy/test_pronotepy.py
@@ -40,6 +40,12 @@ class TestClient(unittest.TestCase):
             self.assertLessEqual(start, hw.date)
             self.assertLessEqual(hw.date, end)
 
+    def test_export_ical(self):
+        import requests
+        ical = client.export_ical()
+        resp = requests.get(ical)
+        self.assertEqual(resp.status_code, 200)
+
     def test_refresh(self):
         client.refresh()
         self.assertEqual(client.session_check(), True)


### PR DESCRIPTION
Closes #79. ICal URL format:
```
<pronote_root>/ical/<prefix>.ics?icalsecurise=<long_string_token>&version=<pronote_version>&param=<param>

pronote_root=usual pronote root eg. https://demo.index-education.net/pronote

prefix=Edt if generating for emploi du temps or Agenda for agenda(?)

long_string_token=received in PageEmploiDuTemps request as ParametreExportiCal

version=received in FonctionParametres: donnees->donneesSec->General->versionPN

param=hex(f"lh={timezone_hour_shift}")
```