### PR TITLE
Set vscode formatter to black in workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "restructuredtext.confPath": "${workspaceFolder}\\docs\\source"
+    "restructuredtext.confPath": "${workspaceFolder}\\docs\\source",
+    "python.formatting.provider": "black"
 }


### PR DESCRIPTION
That it, so if you use vscode, the default formater is black