### PR TITLE
fix parent connection in Bordeaux ENT

### DIFF
--- a/pronotepy/ent/generic_func.py
+++ b/pronotepy/ent/generic_func.py
@@ -50,6 +50,11 @@ def _educonnect(
     # 2nd SAML Authentication
     soup = BeautifulSoup(response.text, "html.parser")
     input_SAMLResponse = soup.find("input", {"name": "SAMLResponse"})
+    if not input_SAMLResponse and response.status_code == 200 and url != response.url:
+        # manual redirect
+        response = session.post(response.url, headers=HEADERS, data=payload)
+        soup = BeautifulSoup(response.text, "html.parser")
+        input_SAMLResponse = soup.find("input", {"name": "SAMLResponse"})
     if not input_SAMLResponse:
         if exceptions:
             raise ENTLoginError(


### PR DESCRIPTION
When connecting to Bordeaux ENT through educonnect, the first reply to the POST request
https://educonnect.education.gouv.fr/idp/profile/SAML2/POST/SSO?execution=e1s1 is a "OK 200" response with a redirect link
https://educonnect.education.gouv.fr/idp/profile/SAML2/POST/SSO?execution=e1s2

We need to retry the POST request to this new URL and it works.