### PR TITLE
Fix Lycée Connecté (Nouvelle-Aquitaine) ENT

### DIFF
--- a/pronotepy/ent/ent.py
+++ b/pronotepy/ent/ent.py
@@ -149,7 +149,9 @@ ent_var = partial(
 
 l_normandie = partial(_open_ent_ng_edu, domain="https://ent.l-educdenormandie.fr")
 
-lyceeconnecte_aquitaine = partial(_open_ent_ng_edu, domain="https://mon.lyceeconnecte.fr/")
+lyceeconnecte_aquitaine = partial(
+    _open_ent_ng_edu, domain="https://mon.lyceeconnecte.fr/"
+)
 
 """WAYF"""
 

--- a/pronotepy/ent/ent.py
+++ b/pronotepy/ent/ent.py
@@ -149,7 +149,7 @@ ent_var = partial(
 
 l_normandie = partial(_open_ent_ng_edu, domain="https://ent.l-educdenormandie.fr")
 
-lyceeconnecte_aquitaine = partial(_open_ent_ng_edu, domain="https://lyceeconnecte.fr/")
+lyceeconnecte_aquitaine = partial(_open_ent_ng_edu, domain="https://mon.lyceeconnecte.fr/")
 
 """WAYF"""
 


### PR DESCRIPTION
The URL for Lycée Connecté was wrong, the right URL is `https://mon.lyceeconnecte.fr/`