### PR TITLE
current_period match against current date

### DIFF
--- a/pronotepy/clients.py
+++ b/pronotepy/clients.py
@@ -599,6 +599,13 @@ class Client(ClientBase):
     @property
     def current_period(self) -> dataClasses.Period:
         """the current period"""
+        # We look for the period matching the current date
+        today = datetime.datetime.today()
+        for period in self.periods:
+            if period.start <= today <= period.end:
+                return period
+
+        #fallback : legacy code
         id_period = self.parametres_utilisateur["donneesSec"]["donnees"]["ressource"][
             "listeOngletsPourPeriodes"
         ]["V"][0]["periodeParDefaut"]["V"]["N"]


### PR DESCRIPTION
For some reason, the current period was the 'Trimestre 1', I figured out how to identify correctly the current period thanks to https://github.com/Vexcited/pornote/blob/2f3b4f79b4be1cb708c9061710eb683a3917aa50/packages/web/src/utils/client.ts#L865

As simple as looking for period matching current date.