### PR TITLE
make Discussion.date a property

### DIFF
--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -1262,6 +1262,7 @@ class Discussion(Object):
 
         return list(sorted(messages.values(), key=lambda x: x.created))
 
+    @property
     def date(self) -> datetime.datetime:
         """
         Date when the discussion was opened. Alias for ``Discussion.messages[0].date``.


### PR DESCRIPTION
I have done all the following:

- [x] added the feature
- [x] added documentation for the feature
- [x] added tests for the feature
- [x] ran mypy, black, and unit tests
