### PR TITLE
fix ac_orleans_tours

### DIFF
--- a/pronotepy/ent/ent.py
+++ b/pronotepy/ent/ent.py
@@ -53,7 +53,7 @@ ecollege_haute_garonne_edu = partial(
 
 ac_orleans_tours = partial(
     _cas_edu,
-    url="https://ent.netocentre.fr/cas/login?&idpId=parentEleveEN-IdP",
+    url="https://ent.netocentre.fr/cas/login?token=ce8ae867a0accc0b7577fcc340bb99f4&idpId=parentEleveEN-IdP",
     redirect_form=False,
 )
 

--- a/pronotepy/test_pronotepy.py
+++ b/pronotepy/test_pronotepy.py
@@ -127,7 +127,7 @@ class TestPeriod(unittest.TestCase):
         all_punishments = []
         for period in client.periods:
             all_punishments.extend(period.punishments)
-        self.assertGreater(len(all_punishments), 0, "there are no punishments")
+        self.assertGreater(len(all_punishments), 0)
 
     def test_class_overall_average(self) -> None:
         a = self.period.class_overall_average

--- a/pronotepy/test_pronotepy.py
+++ b/pronotepy/test_pronotepy.py
@@ -127,7 +127,7 @@ class TestPeriod(unittest.TestCase):
         all_punishments = []
         for period in client.periods:
             all_punishments.extend(period.punishments)
-        self.assertGreater(len(all_punishments), 0)
+        self.assertGreater(len(all_punishments), 0, "there are no punishments")
 
     def test_class_overall_average(self) -> None:
         a = self.period.class_overall_average


### PR DESCRIPTION
I have done all the following:

- [x] added the feature
- [ ] added documentation for the feature
- [ ] added tests for the feature
- [ ] ran mypy, black, and unit tests

fix le ac_orleans_tours, qui a décidé de définir un token constant pour assurer la connexion...
sans ce token l'url redirect sur la page d'accueil de l'ent, entraînant donc un échec de la connexion btw