### PR TITLE
fix(attachments): use proper attribute to retrieve URLs

### DIFF
--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -761,8 +761,8 @@ class Attachment(Object):
         self.type: int = self._resolver(int, "G")  # 0 link, 1 file
 
         if self.type == 0:
-            url: str | None = self._resolver(str, "url", default=None)
-            self.url = self.name if url is None else url
+            url = self._resolver(str, "url", default=None)
+            self.url: str = self.name if url is None else url
         else:
             padd = Padding.pad(
                 json.dumps({"N": self.id, "Actif": True}).replace(" ", "").encode(), 16

--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -761,7 +761,8 @@ class Attachment(Object):
         self.type: int = self._resolver(int, "G")  # 0 link, 1 file
 
         if self.type == 0:
-            self.url = self.name
+            url: str | None = self._resolver(str, "url", default=None)
+            self.url = self.name if url is None else url
         else:
             padd = Padding.pad(
                 json.dumps({"N": self.id, "Actif": True}).replace(" ", "").encode(), 16


### PR DESCRIPTION
I have done all the following:

- [ ] added the feature
- [ ] added documentation for the feature
- [ ] added tests for the feature
- [x] ran mypy, black, and unit tests

Attachments of type "URL" follow this schema (at least on the Pronote version used by the school of my kids): 
```json
"ListePieceJointe": {
  "_T": 24,
  "V": [
    {
      "N": "XXXXXXXXXX",
      "G": 0,
      "url": "https://digipad.app/p/393............"
    },
    {
      "L": "Cours Nuit et Brouillard 2023.pdf",
      "N": "XXXXXXXXXX",
      "G": 1
    },
    {
      "L": "Fiche Nuit et Brouillard.pdf",
      "N": "XXXXXXXXXX",
      "G": 1
    }
  ]
}
```