### PR TITLE
Fix Grade parsing crash when optional fields are missing

### DIFF
--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -34,7 +34,6 @@ from .exceptions import (
 
 from itertools import chain
 
-
 __all__ = (
     "Util",
     "Object",
@@ -714,21 +713,15 @@ class Grade(Object):
         self.average: str = self._resolver(
             Util.grade_parse, "moyenne", "V", strict=False
         )
-        self.max: str = self._resolver(
-            Util.grade_parse, "noteMax", "V", strict=False
-        )
-        self.min: str = self._resolver(
-            Util.grade_parse, "noteMin", "V", strict=False
-        )
+        self.max: str = self._resolver(Util.grade_parse, "noteMax", "V", strict=False)
+        self.min: str = self._resolver(Util.grade_parse, "noteMin", "V", strict=False)
         self.coefficient: str = self._resolver(str, "coefficient", strict=False)
         self.comment: str = self._resolver(str, "commentaire", strict=False)
         self.is_bonus: bool = self._resolver(bool, "estBonus", default=False)
         self.is_optionnal: bool = (
             self._resolver(bool, "estFacultatif", default=False) and not self.is_bonus
         )
-        self.is_out_of_20: bool = self._resolver(
-            bool, "estRamenerSur20", default=False
-        )
+        self.is_out_of_20: bool = self._resolver(bool, "estRamenerSur20", default=False)
 
         del self._resolver
 

--- a/pronotepy/dataClasses.py
+++ b/pronotepy/dataClasses.py
@@ -684,11 +684,11 @@ class Grade(Object):
         date (datetime.date): the date on which the grade was given
         subject (Subject): the subject in which the grade was given
         period (Period): the period in which the grade was given
-        average (str): the average of the class
-        max (str): the highest grade of the test
-        min (str): the lowest grade of the test
-        coefficient (str): the coefficient of the grade
-        comment (str): the comment on the grade description
+        average (Optional[str]): the average of the class
+        max (Optional[str]): the highest grade of the test
+        min (Optional[str]): the lowest grade of the test
+        coefficient (Optional[str]): the coefficient of the grade
+        comment (Optional[str]): the comment on the grade description
         is_bonus (bool): is the grade bonus : only points above 10 count
         is_optionnal (bool): is the grade optionnal : the grade only counts if it increases the average
         is_out_of_20 (bool): is the grade out of 20. Example 8/10 -> 16/20
@@ -714,15 +714,21 @@ class Grade(Object):
         self.average: str = self._resolver(
             Util.grade_parse, "moyenne", "V", strict=False
         )
-        self.max: str = self._resolver(Util.grade_parse, "noteMax", "V")
-        self.min: str = self._resolver(Util.grade_parse, "noteMin", "V")
-        self.coefficient: str = self._resolver(str, "coefficient")
-        self.comment: str = self._resolver(str, "commentaire")
-        self.is_bonus: bool = self._resolver(bool, "estBonus")
-        self.is_optionnal: bool = (
-            self._resolver(bool, "estFacultatif") and not self.is_bonus
+        self.max: str = self._resolver(
+            Util.grade_parse, "noteMax", "V", strict=False
         )
-        self.is_out_of_20: bool = self._resolver(bool, "estRamenerSur20")
+        self.min: str = self._resolver(
+            Util.grade_parse, "noteMin", "V", strict=False
+        )
+        self.coefficient: str = self._resolver(str, "coefficient", strict=False)
+        self.comment: str = self._resolver(str, "commentaire", strict=False)
+        self.is_bonus: bool = self._resolver(bool, "estBonus", default=False)
+        self.is_optionnal: bool = (
+            self._resolver(bool, "estFacultatif", default=False) and not self.is_bonus
+        )
+        self.is_out_of_20: bool = self._resolver(
+            bool, "estRamenerSur20", default=False
+        )
 
         del self._resolver
 

--- a/pronotepy/test_grade_parsing.py
+++ b/pronotepy/test_grade_parsing.py
@@ -1,0 +1,164 @@
+"""Tests for Grade parsing with missing optional fields.
+
+Some Pronote instances (e.g. 0941093c.index-education.net) do not include
+fields like noteMax, noteMin, coefficient, etc. in their grade JSON data.
+These tests verify that Grade objects can be constructed without crashing
+when those fields are absent.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from pronotepy.dataClasses import Grade, Period
+
+
+def _make_grade_json(
+    include_noteMax=True,
+    include_noteMin=True,
+    include_coefficient=True,
+    include_commentaire=True,
+    include_estBonus=True,
+    include_estFacultatif=True,
+    include_estRamenerSur20=True,
+    include_moyenne=True,
+):
+    """Build a grade JSON dict with optional fields toggled on/off."""
+    # Minimal required fields
+    json_dict = {
+        "N": "001",
+        "note": {"V": "15"},
+        "bareme": {"V": "20"},
+        "baremeParDefaut": {"V": "20"},
+        "date": {"V": "15/01/2026"},
+        "service": {"V": {"N": "101", "L": "MATHEMATIQUES", "estServiceGroupe": False}},
+        "periode": {"V": {"N": "test_period_id"}},
+    }
+    if include_noteMax:
+        json_dict["noteMax"] = {"V": "19"}
+    if include_noteMin:
+        json_dict["noteMin"] = {"V": "5"}
+    if include_coefficient:
+        json_dict["coefficient"] = "1"
+    if include_commentaire:
+        json_dict["commentaire"] = "Good work"
+    if include_estBonus:
+        json_dict["estBonus"] = False
+    if include_estFacultatif:
+        json_dict["estFacultatif"] = False
+    if include_estRamenerSur20:
+        json_dict["estRamenerSur20"] = False
+    if include_moyenne:
+        json_dict["moyenne"] = {"V": "12"}
+    return json_dict
+
+
+class TestGradeMissingFields(unittest.TestCase):
+    """Test that Grade parsing handles missing optional fields gracefully."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Create a mock Period instance so the period resolver can find it
+        mock_period = MagicMock(spec=Period)
+        mock_period.id = "test_period_id"
+        Period.instances.add(mock_period)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Clean up mock period instances
+        Period.instances = {p for p in Period.instances if not isinstance(p, MagicMock)}
+
+    def test_all_fields_present(self):
+        """Parsing works when all fields are present."""
+        json_dict = _make_grade_json()
+        grade = Grade(json_dict)
+        self.assertEqual(grade.grade, "15")
+        self.assertEqual(grade.max, "19")
+        self.assertEqual(grade.min, "5")
+        self.assertEqual(grade.coefficient, "1")
+        self.assertEqual(grade.comment, "Good work")
+        self.assertFalse(grade.is_bonus)
+        self.assertFalse(grade.is_optionnal)
+        self.assertFalse(grade.is_out_of_20)
+
+    def test_missing_noteMax(self):
+        """Parsing does not crash when noteMax is missing."""
+        json_dict = _make_grade_json(include_noteMax=False)
+        grade = Grade(json_dict)
+        self.assertIsNone(grade.max)
+        # Other fields should still be parsed correctly
+        self.assertEqual(grade.grade, "15")
+        self.assertEqual(grade.min, "5")
+
+    def test_missing_noteMin(self):
+        """Parsing does not crash when noteMin is missing."""
+        json_dict = _make_grade_json(include_noteMin=False)
+        grade = Grade(json_dict)
+        self.assertIsNone(grade.min)
+
+    def test_missing_coefficient(self):
+        """Parsing does not crash when coefficient is missing."""
+        json_dict = _make_grade_json(include_coefficient=False)
+        grade = Grade(json_dict)
+        self.assertIsNone(grade.coefficient)
+
+    def test_missing_commentaire(self):
+        """Parsing does not crash when commentaire is missing."""
+        json_dict = _make_grade_json(include_commentaire=False)
+        grade = Grade(json_dict)
+        self.assertIsNone(grade.comment)
+
+    def test_missing_estBonus(self):
+        """Parsing does not crash when estBonus is missing."""
+        json_dict = _make_grade_json(include_estBonus=False)
+        grade = Grade(json_dict)
+        self.assertFalse(grade.is_bonus)
+
+    def test_missing_estFacultatif(self):
+        """Parsing does not crash when estFacultatif is missing."""
+        json_dict = _make_grade_json(include_estFacultatif=False)
+        grade = Grade(json_dict)
+        self.assertFalse(grade.is_optionnal)
+
+    def test_missing_estRamenerSur20(self):
+        """Parsing does not crash when estRamenerSur20 is missing."""
+        json_dict = _make_grade_json(include_estRamenerSur20=False)
+        grade = Grade(json_dict)
+        self.assertFalse(grade.is_out_of_20)
+
+    def test_missing_moyenne(self):
+        """Parsing does not crash when moyenne is missing."""
+        json_dict = _make_grade_json(include_moyenne=False)
+        grade = Grade(json_dict)
+        self.assertIsNone(grade.average)
+
+    def test_all_optional_fields_missing(self):
+        """Parsing does not crash when ALL optional fields are missing.
+
+        This simulates the worst case scenario where a Pronote instance
+        returns only the bare minimum grade data.
+        """
+        json_dict = _make_grade_json(
+            include_noteMax=False,
+            include_noteMin=False,
+            include_coefficient=False,
+            include_commentaire=False,
+            include_estBonus=False,
+            include_estFacultatif=False,
+            include_estRamenerSur20=False,
+            include_moyenne=False,
+        )
+        grade = Grade(json_dict)
+        self.assertEqual(grade.grade, "15")
+        self.assertEqual(grade.out_of, "20")
+        self.assertIsNone(grade.max)
+        self.assertIsNone(grade.min)
+        self.assertIsNone(grade.coefficient)
+        self.assertIsNone(grade.comment)
+        self.assertFalse(grade.is_bonus)
+        self.assertFalse(grade.is_optionnal)
+        self.assertFalse(grade.is_out_of_20)
+        self.assertIsNone(grade.average)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pronotepy/test_grade_parsing.py
+++ b/pronotepy/test_grade_parsing.py
@@ -13,18 +13,18 @@ from pronotepy.dataClasses import Grade, Period
 
 
 def _make_grade_json(
-    include_noteMax=True,
-    include_noteMin=True,
-    include_coefficient=True,
-    include_commentaire=True,
-    include_estBonus=True,
-    include_estFacultatif=True,
-    include_estRamenerSur20=True,
-    include_moyenne=True,
-):
+    include_noteMax: bool =True,
+    include_noteMin: bool =True,
+    include_coefficient: bool =True,
+    include_commentaire: bool=True,
+    include_estBonus: bool=True,
+    include_estFacultatif: bool=True,
+    include_estRamenerSur20: bool=True,
+    include_moyenne: bool=True,
+) -> dict:
     """Build a grade JSON dict with optional fields toggled on/off."""
     # Minimal required fields
-    json_dict = {
+    json_dict: dict = {
         "N": "001",
         "note": {"V": "15"},
         "bareme": {"V": "20"},
@@ -56,18 +56,18 @@ class TestGradeMissingFields(unittest.TestCase):
     """Test that Grade parsing handles missing optional fields gracefully."""
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         # Create a mock Period instance so the period resolver can find it
         mock_period = MagicMock(spec=Period)
         mock_period.id = "test_period_id"
         Period.instances.add(mock_period)
 
     @classmethod
-    def tearDownClass(cls):
+    def tearDownClass(cls) -> None:
         # Clean up mock period instances
         Period.instances = {p for p in Period.instances if not isinstance(p, MagicMock)}
 
-    def test_all_fields_present(self):
+    def test_all_fields_present(self) -> None:
         """Parsing works when all fields are present."""
         json_dict = _make_grade_json()
         grade = Grade(json_dict)
@@ -80,7 +80,7 @@ class TestGradeMissingFields(unittest.TestCase):
         self.assertFalse(grade.is_optionnal)
         self.assertFalse(grade.is_out_of_20)
 
-    def test_missing_noteMax(self):
+    def test_missing_noteMax(self) -> None:
         """Parsing does not crash when noteMax is missing."""
         json_dict = _make_grade_json(include_noteMax=False)
         grade = Grade(json_dict)
@@ -89,49 +89,49 @@ class TestGradeMissingFields(unittest.TestCase):
         self.assertEqual(grade.grade, "15")
         self.assertEqual(grade.min, "5")
 
-    def test_missing_noteMin(self):
+    def test_missing_noteMin(self) -> None:
         """Parsing does not crash when noteMin is missing."""
         json_dict = _make_grade_json(include_noteMin=False)
         grade = Grade(json_dict)
         self.assertIsNone(grade.min)
 
-    def test_missing_coefficient(self):
+    def test_missing_coefficient(self) -> None:
         """Parsing does not crash when coefficient is missing."""
         json_dict = _make_grade_json(include_coefficient=False)
         grade = Grade(json_dict)
         self.assertIsNone(grade.coefficient)
 
-    def test_missing_commentaire(self):
+    def test_missing_commentaire(self) -> None:
         """Parsing does not crash when commentaire is missing."""
         json_dict = _make_grade_json(include_commentaire=False)
         grade = Grade(json_dict)
         self.assertIsNone(grade.comment)
 
-    def test_missing_estBonus(self):
+    def test_missing_estBonus(self) -> None:
         """Parsing does not crash when estBonus is missing."""
         json_dict = _make_grade_json(include_estBonus=False)
         grade = Grade(json_dict)
         self.assertFalse(grade.is_bonus)
 
-    def test_missing_estFacultatif(self):
+    def test_missing_estFacultatif(self) -> None:
         """Parsing does not crash when estFacultatif is missing."""
         json_dict = _make_grade_json(include_estFacultatif=False)
         grade = Grade(json_dict)
         self.assertFalse(grade.is_optionnal)
 
-    def test_missing_estRamenerSur20(self):
+    def test_missing_estRamenerSur20(self) -> None:
         """Parsing does not crash when estRamenerSur20 is missing."""
         json_dict = _make_grade_json(include_estRamenerSur20=False)
         grade = Grade(json_dict)
         self.assertFalse(grade.is_out_of_20)
 
-    def test_missing_moyenne(self):
+    def test_missing_moyenne(self) -> None:
         """Parsing does not crash when moyenne is missing."""
         json_dict = _make_grade_json(include_moyenne=False)
         grade = Grade(json_dict)
         self.assertIsNone(grade.average)
 
-    def test_all_optional_fields_missing(self):
+    def test_all_optional_fields_missing(self) -> None:
         """Parsing does not crash when ALL optional fields are missing.
 
         This simulates the worst case scenario where a Pronote instance

--- a/pronotepy/test_grade_parsing.py
+++ b/pronotepy/test_grade_parsing.py
@@ -13,14 +13,14 @@ from pronotepy.dataClasses import Grade, Period
 
 
 def _make_grade_json(
-    include_noteMax: bool =True,
-    include_noteMin: bool =True,
-    include_coefficient: bool =True,
-    include_commentaire: bool=True,
-    include_estBonus: bool=True,
-    include_estFacultatif: bool=True,
-    include_estRamenerSur20: bool=True,
-    include_moyenne: bool=True,
+    include_noteMax: bool = True,
+    include_noteMin: bool = True,
+    include_coefficient: bool = True,
+    include_commentaire: bool = True,
+    include_estBonus: bool = True,
+    include_estFacultatif: bool = True,
+    include_estRamenerSur20: bool = True,
+    include_moyenne: bool = True,
 ) -> dict:
     """Build a grade JSON dict with optional fields toggled on/off."""
     # Minimal required fields

--- a/pronotepy/test_pronotepy.py
+++ b/pronotepy/test_pronotepy.py
@@ -6,7 +6,6 @@ from pronotepy import DiscussionClosed
 
 import warnings
 
-
 client = pronotepy.Client(
     "https://demo.index-education.net/pronote/eleve.html", "demonstration", "pronotevs"
 )


### PR DESCRIPTION
## Summary

- Some Pronote instances (e.g. `0941093c.index-education.net`) do not include fields like `noteMax`, `noteMin`, `coefficient`, `commentaire`, `estBonus`, `estFacultatif`, or `estRamenerSur20` in their grade JSON data. This caused a `ParsingError` ("Could not follow path") when calling `client.current_period.grades`.
- Use `strict=False` for string/grade fields (`max`, `min`, `coefficient`, `comment`) so they gracefully return `None` when missing, and use `default=False` for boolean fields (`is_bonus`, `is_optionnal`, `is_out_of_20`) so they default to `False`. This matches the existing pattern already used for `average` and `default_out_of`.
- Updated docstring type annotations to reflect that `max`, `min`, `coefficient`, and `comment` are now `Optional[str]`.

## Reproduction

```python
import pronotepy

client = pronotepy.Client(
    "https://0941093c.index-education.net/pronote/eleve.html",
    username="...",
    password="..."
)

# This crashes with:
# pronotepy.exceptions.ParsingError: Could not follow path
grades = client.current_period.grades
```

The crash occurs at `dataClasses.py` line 717 because the grade JSON from this school does not contain the `noteMax` key.

## Test plan

- [x] Added unit tests in `pronotepy/test_grade_parsing.py` that verify `Grade` objects can be constructed when any combination of optional fields is missing
- [x] All 10 new tests pass
- [ ] Existing tests against the demo Pronote server should continue to pass (fields are still parsed normally when present)