### PR TITLE
docs: rewrite URL for pawnote and add blocksnote

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > Pronotepy is currently in maintenance mode. **We will continue to fix bugs** and adapt to PRONOTE changes, but will not be adding
 > new features. **Please do NOT create PRs with new features.** They will not get merged.
 >
-> If you are looking for an alternative that is under active developement, consider using [Pawnote](https://github.com/LiterateInk/Pawnote) (JavaScript/TS) instead.
+> If you are looking for an alternative that is under active developement, consider using [PRONOTE (ex. Pawnote)](https://radicle.network/nodes/seed.vexcited.com/rad%3Az252zKnhJrntJAd6Spt6CYdqRxAXr) (JS/TS) or [Blocksnote](https://github.com/BlocksHub/Blocksnote) (JS/TS) instead.
 
 <br />
 <p align="center">


### PR DESCRIPTION
I am moving my repositories to Radicle so I had to update the URL here for convenience since a lot of people seem to come from there.

I also added my friend's repository (@raphckrman) who's working on Blocksnote, another JS/TS package for PRONOTE which is currently a bit more up to date since I paused development recently (will provide more updates soon when I have time)