### PR TITLE
Fix login on Pronote instances that no longer alea-wrap the challenge

### DIFF
--- a/pronotepy/clients.py
+++ b/pronotepy/clients.py
@@ -332,20 +332,19 @@ class ClientBase:
             e.aes_set_key((username + motdepasse).encode())
 
         # challenge
+        challenge_crypto_error: Optional[CryptoError] = None
         try:
             dec = e.aes_decrypt(bytes.fromhex(challenge))
             dec_no_alea = _enleverAlea(dec.decode())
             ch = e.aes_encrypt(dec_no_alea.encode()).hex()
         except CryptoError as ex:
-            if self.login_mode == "qr_code":
-                ex.args += (
-                    "exception happened during login -> probably the qr code has expired (qr code is valid during 10 minutes)",
-                )
-            else:
-                ex.args += (
-                    "exception happened during login -> probably bad username/password",
-                )
-            raise
+            # some Pronote instances (since ~2026.2.5) no longer alea-wrap the
+            # login challenge and expect it to be re-encrypted directly instead
+            # of decrypted/stripped/re-encrypted. Keep the original error around:
+            # if this fallback also fails to log in, it's the more useful one to
+            # surface (a genuinely bad username/password fails the same way).
+            challenge_crypto_error = ex
+            ch = e.aes_encrypt(challenge.encode()).hex()
 
         # send
         auth_json = {
@@ -400,6 +399,16 @@ class ClientBase:
             return True
         else:
             log.info("login failed")
+            if challenge_crypto_error is not None:
+                if self.login_mode == "qr_code":
+                    challenge_crypto_error.args += (
+                        "exception happened during login -> probably the qr code has expired (qr code is valid during 10 minutes)",
+                    )
+                else:
+                    challenge_crypto_error.args += (
+                        "exception happened during login -> probably bad username/password",
+                    )
+                raise challenge_crypto_error
             return False
 
     def _do_2fa(


### PR DESCRIPTION
## Summary

Since the 2026 school year start (2026-09-02), some Pronote instances (2026.2.5+) no longer apply `ajouterAlea`/`enleverAlea` to the login challenge. The live JS for these instances only alea-wraps when explicitly called with `avecAlea: true`, and no login call site does that anymore — the challenge is now expected to be AES-encrypted directly, not decrypted/alea-stripped/re-encrypted.

The old path in `_login()` fails PKCS7 unpadding against such a challenge, so every login on a migrated instance raises `CryptoError`, even with correct credentials (confirmed independently by multiple people on the issue, and against the project's own `demo.index-education.net`, which has also migrated).

## Fix

- `_login()` now falls back to directly re-encrypting the raw challenge when the legacy decrypt/strip/re-encrypt step raises `CryptoError`, so both old- and new-style instances work.
- The original `CryptoError` is kept and re-raised (with the usual "probably bad username/password" / "qr code expired" annotation) if the fallback *also* fails to authenticate, so a genuinely wrong password still surfaces a clear error instead of failing silently later on.

Fixes #346

## Test plan

- [x] Verified end-to-end against a real, migrated Pronote instance (`ParentClient`, username/password login) — login succeeds and homework data is retrieved.
- [ ] Would appreciate a run against `demo.index-education.net` / the existing test suite by a maintainer, since I don't have write access to CI here.